### PR TITLE
fix notification issue

### DIFF
--- a/src/main/java/com/studentlife/StudentLifeAPIs/Controller/DashboardController.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Controller/DashboardController.java
@@ -3,6 +3,12 @@ package com.studentlife.StudentLifeAPIs.Controller;
 import com.studentlife.StudentLifeAPIs.DTO.Response.ApiResponse;
 import com.studentlife.StudentLifeAPIs.DTO.Response.DashboardResponse;
 import com.studentlife.StudentLifeAPIs.Service.DashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,11 +18,43 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/dashboard")
 @RequiredArgsConstructor
+@Tag(name = "Dashboard", description = "Single aggregated endpoint that powers the student dashboard UI")
+@SecurityRequirement(name = "bearerAuth")
 public class DashboardController {
 
     private final DashboardService dashboardService;
 
     @GetMapping
+    @Operation(
+        summary = "Get dashboard",
+        description = """
+            Returns all data needed to render the student dashboard in a single request:
+
+            - **greeting** — student's first name + how many deadlines are due this week
+            - **todaySchedule** — the class currently in progress (with % elapsed) + next classes today
+            - **assignmentStatus** — counts for upcoming / overdue / done + the soonest featured assignment
+            - **progressOverview** — average completion % across all assignments + on-track / behind / done counts
+            - **upcomingDeadlines** — up to 5 non-completed assignments, overdue ones first, each tagged with an urgency badge (OVERDUE, DUE_SOON, GROUP, UPCOMING)
+            - **groupActivity** — recent group chat messages from other members across all the student's groups
+
+            Requires a valid JWT Bearer token. Accessible by any authenticated user.
+            """
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "Dashboard data loaded successfully",
+            content = @Content(schema = @Schema(implementation = DashboardResponse.class))
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "Missing or invalid JWT token"
+        ),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "403",
+            description = "Access denied"
+        )
+    })
     public ResponseEntity<ApiResponse<DashboardResponse>> getDashboard() {
         return ResponseEntity.ok(dashboardService.getDashboard());
     }

--- a/src/main/java/com/studentlife/StudentLifeAPIs/Controller/NotificationController.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Controller/NotificationController.java
@@ -8,6 +8,7 @@ import com.studentlife.StudentLifeAPIs.Enum.NotificationType;
 import com.studentlife.StudentLifeAPIs.Service.NotificationService;
 import com.studentlife.StudentLifeAPIs.Utils.AuthUtil;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,6 +22,19 @@ public class NotificationController {
     private final NotificationService notificationService;
     private final AuthUtil authUtil;
 
+    @GetMapping
+    public  ResponseEntity<ApiResponse<List<NotificationResponse>>> getAllNotification() {
+        Users currentUser = authUtil.getAuthenticatedUser();
+        return ResponseEntity.ok(new ApiResponse<>(
+                200,
+                true,
+                "Notification retrieved",
+                notificationService.getAllNotifications(
+                        currentUser.getId()
+                )
+        ));
+    }
+
     @PostMapping("/send")
     public ResponseEntity<ApiResponse<NotificationResponse>> send(
             @RequestBody NotificationRequest request,
@@ -31,21 +45,57 @@ public class NotificationController {
     }
 
     @GetMapping("/unread")
-    public ResponseEntity<List<NotificationResponse>> getUnread() {
+    public  ResponseEntity<ApiResponse<List<NotificationResponse>>> getUnread() {
         Users currentUser = authUtil.getAuthenticatedUser();
-        return ResponseEntity.ok(notificationService.getUnreadNotifications(currentUser.getId()));
+        return ResponseEntity.ok(new ApiResponse<>(
+                200,
+                true,
+                "Get un read notification successfully",
+                notificationService.getUnreadNotifications(currentUser.getId())
+        ));
     }
 
     @GetMapping("/unread/count")
-    public ResponseEntity<Long> countUnread() {
+    public ResponseEntity<ApiResponse<Long>> countUnread() {
         Users currentUser = authUtil.getAuthenticatedUser();
-        return ResponseEntity.ok(notificationService.countUnread(currentUser.getId()));
+        return ResponseEntity.ok(new ApiResponse<>(
+                200,
+                true,
+                "Unread count",
+                notificationService.countUnread(currentUser.getId())
+        ));
     }
 
     @PutMapping("/mark-all-read")
     public ResponseEntity<ApiResponse<?>> markAllAsRead() {
         Users currentUser = authUtil.getAuthenticatedUser();
         notificationService.markAllAsRead(currentUser.getId());
-        return ResponseEntity.ok(new ApiResponse<>(200, true, "All notifications marked as read.", null));
+        return ResponseEntity.ok(new ApiResponse<>(
+                200,
+                true,
+                "All notifications marked as read."
+        ));
+    }
+
+    @PatchMapping("/{id}/read")
+    public ResponseEntity<ApiResponse<?>> markAsRead(@PathVariable Long id) {
+        Users currentUser = authUtil.getAuthenticatedUser();
+        notificationService.markAsRead(id, currentUser.getId());
+        return ResponseEntity.ok(new ApiResponse<>(
+                200,
+                true,
+                "Notification marked as read."
+        ));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<?>> deleteNotification(@PathVariable Long id) {
+        Users currentUser = authUtil.getAuthenticatedUser();
+        notificationService.deleteNotification(id, currentUser.getId());
+        return ResponseEntity.ok(new ApiResponse<>(
+                200,
+                true,
+                "Notification deleted."
+        ));
     }
 }

--- a/src/main/java/com/studentlife/StudentLifeAPIs/Controller/UserController.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Controller/UserController.java
@@ -8,7 +8,6 @@ import com.studentlife.StudentLifeAPIs.DTO.Response.UserResponse;
 import com.studentlife.StudentLifeAPIs.Service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/studentlife/StudentLifeAPIs/DTO/Response/DashboardResponse.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/DTO/Response/DashboardResponse.java
@@ -1,5 +1,6 @@
 package com.studentlife.StudentLifeAPIs.DTO.Response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,101 +8,217 @@ import java.util.List;
 
 @Data
 @Builder
+@Schema(description = "Full dashboard payload — all sections needed to render the student dashboard UI in one call")
 public class DashboardResponse {
 
+    @Schema(description = "Personalised greeting section shown at the top of the dashboard")
     private Greeting greeting;
+
+    @Schema(description = "Today's class schedule: the class currently in progress and the next upcoming classes")
     private TodaySchedule todaySchedule;
+
+    @Schema(description = "Assignment counts by status plus the next upcoming assignment")
     private AssignmentStatus assignmentStatus;
+
+    @Schema(description = "Overall completion percentage and per-category counts for the progress ring")
     private ProgressOverview progressOverview;
+
+    @Schema(description = "Up to 5 upcoming/overdue deadlines sorted by urgency then due date")
     private List<DeadlineItem> upcomingDeadlines;
+
+    @Schema(description = "Collaborative group activity feed and active group count")
     private GroupActivity groupActivity;
+
+    // ── Greeting ──────────────────────────────────────────────────────────────
 
     @Data
     @Builder
+    @Schema(description = "Greeting section")
     public static class Greeting {
+
+        @Schema(description = "User's first name", example = "Sal")
         private String firstName;
+
+        @Schema(description = "Number of non-completed assignments due within the next 7 days", example = "2")
         private int deadlinesThisWeek;
     }
 
+    // ── Today's Schedule ──────────────────────────────────────────────────────
+
     @Data
     @Builder
+    @Schema(description = "Today's schedule section")
     public static class TodaySchedule {
+
+        @Schema(description = "The class currently in progress based on server time. Null if no class is happening right now.")
         private CurrentClass currentClass;
+
+        @Schema(description = "Next classes today after the current time, sorted by start time, max 3")
         private List<UpNextItem> upNext;
     }
 
     @Data
     @Builder
+    @Schema(description = "Class currently in progress")
     public static class CurrentClass {
+
+        @Schema(description = "Schedule ID", example = "12")
         private Long id;
+
+        @Schema(description = "Class title", example = "English Literature")
         private String title;
+
+        @Schema(description = "Room or location", example = "Room 204")
         private String location;
+
+        @Schema(description = "Total class duration in minutes", example = "60")
         private int durationMinutes;
+
+        @Schema(description = "Formatted end time (12-hour clock)", example = "11:00 AM")
         private String endsAt;
+
+        @Schema(description = "How far through the class the student is, 0–100", example = "67")
         private int progressPercent;
     }
 
     @Data
     @Builder
+    @Schema(description = "An upcoming class later today")
     public static class UpNextItem {
+
+        @Schema(description = "Schedule ID", example = "15")
         private Long id;
+
+        @Schema(description = "Class title", example = "Computer Science")
         private String title;
+
+        @Schema(description = "Room or location", example = "Lab 3")
         private String location;
+
+        @Schema(description = "Formatted start time (12-hour clock)", example = "1:30 PM")
         private String startTime;
     }
 
+    // ── Assignment Status ─────────────────────────────────────────────────────
+
     @Data
     @Builder
+    @Schema(description = "Assignment status counts for the status card")
     public static class AssignmentStatus {
+
+        @Schema(description = "Assignments with status PENDING or IN_PROGRESS", example = "4")
         private int upcoming;
+
+        @Schema(description = "Assignments with status OVERDUE", example = "1")
         private int overdue;
+
+        @Schema(description = "Assignments with status COMPLETED", example = "3")
         private int done;
+
+        @Schema(description = "The soonest upcoming assignment to highlight in the card. Null if none.")
         private FeaturedAssignment featured;
     }
 
     @Data
     @Builder
+    @Schema(description = "Highlighted upcoming assignment shown inside the status card")
     public static class FeaturedAssignment {
+
+        @Schema(description = "Assignment ID", example = "7")
         private Long id;
+
+        @Schema(description = "Assignment title", example = "Contribution Accounting")
         private String title;
+
+        @Schema(description = "Subject name", example = "Mathematics")
         private String subject;
+
+        @Schema(description = "Human-readable due date label", example = "Due tomorrow")
         private String dueDateLabel;
     }
 
+    // ── Progress Overview ─────────────────────────────────────────────────────
+
     @Data
     @Builder
+    @Schema(description = "Progress ring data")
     public static class ProgressOverview {
+
+        @Schema(description = "Average progress percentage across all accessible assignments (0–100)", example = "75")
         private int overallPercent;
+
+        @Schema(description = "Count of PENDING + IN_PROGRESS assignments", example = "6")
         private int onTrack;
+
+        @Schema(description = "Count of OVERDUE assignments", example = "1")
         private int behind;
+
+        @Schema(description = "Count of COMPLETED assignments", example = "3")
         private int done;
     }
 
-    @Data
-    @Builder
-    public static class DeadlineItem {
-        private Long id;
-        private String title;
-        private String subject;
-        private String dueDateLabel;
-        private String urgency;
-        private boolean isGroup;
-    }
+    // ── Upcoming Deadlines ────────────────────────────────────────────────────
 
     @Data
     @Builder
+    @Schema(description = "A single deadline entry in the upcoming deadlines list")
+    public static class DeadlineItem {
+
+        @Schema(description = "Assignment ID", example = "3")
+        private Long id;
+
+        @Schema(description = "Assignment title", example = "Math Assignment")
+        private String title;
+
+        @Schema(description = "Subject name", example = "Mathematics")
+        private String subject;
+
+        @Schema(description = "Human-readable due date label", example = "Due tomorrow")
+        private String dueDateLabel;
+
+        @Schema(
+            description = "Urgency badge to display. One of: OVERDUE, DUE_SOON (within 48 h), GROUP (collaborative), UPCOMING",
+            example = "OVERDUE",
+            allowableValues = {"OVERDUE", "DUE_SOON", "GROUP", "UPCOMING"}
+        )
+        private String urgency;
+
+        @Schema(description = "True if this assignment has other accepted group members", example = "false")
+        private boolean isGroup;
+    }
+
+    // ── Group Activity ────────────────────────────────────────────────────────
+
+    @Data
+    @Builder
+    @Schema(description = "Collaboration / group activity section")
     public static class GroupActivity {
+
+        @Schema(description = "Number of study groups the current user has actively joined", example = "2")
         private int activeGroups;
+
+        @Schema(description = "Up to 5 most recent group chat messages from other members")
         private List<ActivityItem> recentActivity;
     }
 
     @Data
     @Builder
+    @Schema(description = "A single activity item in the group feed")
     public static class ActivityItem {
+
+        @Schema(description = "Full name of the person who sent the message", example = "Emma B.")
         private String actorName;
+
+        @Schema(description = "2-letter initials for avatar display", example = "EB")
         private String actorInitials;
+
+        @Schema(description = "Title of the assignment / group the message belongs to", example = "Physics Project")
         private String groupName;
+
+        @Schema(description = "Assignment ID (use to deep-link into the group chat)", example = "5")
         private Long groupId;
+
+        @Schema(description = "Human-readable time since the message was sent", example = "2h ago")
         private String timeAgo;
     }
 }

--- a/src/main/java/com/studentlife/StudentLifeAPIs/Scheduler/AssignmentReminderScheduler.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Scheduler/AssignmentReminderScheduler.java
@@ -1,10 +1,13 @@
 package com.studentlife.StudentLifeAPIs.Scheduler;
 
+import com.studentlife.StudentLifeAPIs.DTO.Request.NotificationRequest;
 import com.studentlife.StudentLifeAPIs.Entity.Assignments;
 import com.studentlife.StudentLifeAPIs.Entity.ReminderLog;
 import com.studentlife.StudentLifeAPIs.Enum.AssignmentStatus;
+import com.studentlife.StudentLifeAPIs.Enum.NotificationType;
 import com.studentlife.StudentLifeAPIs.Repository.AssignmentRepository;
 import com.studentlife.StudentLifeAPIs.Repository.ReminderLogRepository;
+import com.studentlife.StudentLifeAPIs.Service.NotificationService;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +31,7 @@ public class AssignmentReminderScheduler {
     private final AssignmentRepository    assignmentRepository;
     private final ReminderLogRepository   reminderLogRepository;
     private final JavaMailSender          mailSender;
+    private final NotificationService notificationService;
 
     @Value("${app.backend.url}")
     private String backendUrl;
@@ -73,6 +77,12 @@ public class AssignmentReminderScheduler {
 
             try {
                 sendReminderEmail(assignment, label);
+
+                NotificationRequest notificationRequest = new NotificationRequest();
+                notificationRequest.setTitle("Assignment due in" + label);
+                notificationRequest.setMessage("\"" + assignment.getTitle() + "\" is due in " + label + ". Progress: " +
+                        assignment.getProgress() + "%");
+                notificationService.sendNotification(notificationRequest, NotificationType.REMINDER, assignment.getUser());
 
                 // Record that we sent it — prevents duplicate sends
                 reminderLogRepository.save(ReminderLog.builder()

--- a/src/main/java/com/studentlife/StudentLifeAPIs/Service/Impl/DashboardServiceImpl.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Service/Impl/DashboardServiceImpl.java
@@ -75,7 +75,7 @@ public class DashboardServiceImpl implements DashboardService {
     // ── Greeting ──────────────────────────────────────────────────────────────
 
     private DashboardResponse.Greeting buildGreeting(Users user, LocalDateTime now, List<Assignments> allAssignments) {
-        String firstName = user.getFullname() != null && !user.getFullname().isBlank()
+        String lastName = user.getFullname() != null && !user.getFullname().isBlank()
                 ? user.getFullname().split("\\s+")[1]
                 : user.getUsername();
 
@@ -88,7 +88,7 @@ public class DashboardServiceImpl implements DashboardService {
                 .count();
 
         return DashboardResponse.Greeting.builder()
-                .firstName(firstName)
+                .firstName(lastName)
                 .deadlinesThisWeek((int) deadlinesThisWeek)
                 .build();
     }

--- a/src/main/java/com/studentlife/StudentLifeAPIs/Service/Impl/GroupChatServiceImpl.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Service/Impl/GroupChatServiceImpl.java
@@ -145,25 +145,6 @@ public class GroupChatServiceImpl implements GroupChatService {
             }
         }
 
-        Users owner = assignment.getUser();
-        if (!owner.getId().equals(senderId)) {
-            oneSignalService.sendPushToUser(
-                    owner.getOneSignalPlayerId(),
-                    sender.getFullname(),
-                    request.getContent()
-            );
-        }
-
-        for (AssignmentMember member : members) {
-            if (!member.getUser().getId().equals(senderId)) {
-                oneSignalService.sendPushToUser(
-                        member.getUser().getOneSignalPlayerId(),
-                        sender.getFullname(),
-                        request.getContent()
-                );
-            }
-        }
-
         log.info("[Chat] Message sent in group {} by user {}", request.getAssignmentId(), senderId);
 
         return response;

--- a/src/main/java/com/studentlife/StudentLifeAPIs/Service/Impl/NotificationServiceImpl.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Service/Impl/NotificationServiceImpl.java
@@ -10,12 +10,16 @@ import com.studentlife.StudentLifeAPIs.Mapper.NotificationMapper;
 import com.studentlife.StudentLifeAPIs.Repository.NotificationRepository;
 import com.studentlife.StudentLifeAPIs.Service.NotificationService;
 import com.studentlife.StudentLifeAPIs.Service.OneSignalService;
+import com.studentlife.StudentLifeAPIs.Utils.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+
+import static com.studentlife.StudentLifeAPIs.Exception.ErrorsExceptionFactory.forbidden;
+import static com.studentlife.StudentLifeAPIs.Exception.ErrorsExceptionFactory.notFound;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +29,14 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationMapper notificationMapper;
     private final SimpMessagingTemplate messagingTemplate;
     private final OneSignalService oneSignalService;
+
+    @Override
+    public List<NotificationResponse> getAllNotifications(Long userId) {
+        return notificationRepository.findByRecipientIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(notificationMapper::toResponse)
+                .toList();
+    }
 
     @Override
     @Transactional
@@ -87,5 +99,26 @@ public class NotificationServiceImpl implements NotificationService {
                 .findByRecipientIdAndIsReadFalse(userId);
         notifications.forEach(n -> n.setRead(true));
         notificationRepository.saveAll(notifications);
+    }
+
+    @Override
+    public void markAsRead(Long id, Long userId) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> notFound("Notification not found."));
+        if (!notification.getRecipient().getId().equals(userId)) {
+            throw forbidden("You do not have access to this notification");
+        }
+        notification.setRead(true);
+        notificationRepository.save(notification);
+    }
+
+    @Override
+    public void deleteNotification(Long id, Long userId) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> notFound("Notification not found."));
+        if (!notification.getRecipient().getId().equals(userId)) {
+            throw forbidden("You do not have access to this notification");
+        }
+        notificationRepository.delete(notification);
     }
 }

--- a/src/main/java/com/studentlife/StudentLifeAPIs/Service/Impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Service/Impl/ScheduleServiceImpl.java
@@ -5,7 +5,6 @@ import com.studentlife.StudentLifeAPIs.DTO.Response.ApiResponse;
 import com.studentlife.StudentLifeAPIs.DTO.Response.ScheduleResponse;
 import com.studentlife.StudentLifeAPIs.Entity.Schedules;
 import com.studentlife.StudentLifeAPIs.Entity.Users;
-import com.studentlife.StudentLifeAPIs.Enum.NotificationType;
 import com.studentlife.StudentLifeAPIs.Enum.ScheduleType;
 import com.studentlife.StudentLifeAPIs.Mapper.ScheduleMapper;
 import com.studentlife.StudentLifeAPIs.Repository.ScheduleRepository;
@@ -87,11 +86,6 @@ public class ScheduleServiceImpl implements ScheduleService {
         schedule.setUser(currentUser);
         scheduleRepository.save(schedule);
 
-        NotificationRequest notifRequest = new NotificationRequest();
-        notifRequest.setTitle("Schedule Created");
-        notifRequest.setMessage("Your schedule \"" + schedule.getTitle() + "\" has been created.");
-        notificationService.sendNotification(notifRequest, NotificationType.SCHEDULE, currentUser);
-
         return new ApiResponse<>(
                 201,
                 true,
@@ -113,11 +107,6 @@ public class ScheduleServiceImpl implements ScheduleService {
         Schedules schedule = scheduleMapper.toEntityFromRecurring(request);
         schedule.setUser(currentUser);
         scheduleRepository.save(schedule);
-
-        NotificationRequest notifRequest = new NotificationRequest();
-        notifRequest.setTitle("Recurring Schedule Created");
-        notifRequest.setMessage("Your recurring schedule \"" + schedule.getTitle() + "\" has been created.");
-        notificationService.sendNotification(notifRequest, NotificationType.SCHEDULE, currentUser);
 
         return new ApiResponse<>(
                 201,
@@ -151,11 +140,6 @@ public class ScheduleServiceImpl implements ScheduleService {
         }
 
         scheduleRepository.save(schedule);
-
-        NotificationRequest notifRequest = new NotificationRequest();
-        notifRequest.setTitle("Schedule Updated");
-        notifRequest.setMessage("Your schedule \"" + schedule.getTitle() + "\" has been updated.");
-        notificationService.sendNotification(notifRequest, NotificationType.SCHEDULE, currentUser);
 
         return new ApiResponse<>(
                 200,

--- a/src/main/java/com/studentlife/StudentLifeAPIs/Service/NotificationService.java
+++ b/src/main/java/com/studentlife/StudentLifeAPIs/Service/NotificationService.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 public interface NotificationService {
 
+    List<NotificationResponse> getAllNotifications(Long userId);
+
     ApiResponse<NotificationResponse> sendNotification(NotificationRequest request, NotificationType type, Users recipient);
 
     void sendRealTimeNotification(Long userId, NotificationResponse notification);
@@ -19,4 +21,8 @@ public interface NotificationService {
     long countUnread(Long userId);
 
     void markAllAsRead(Long userId);
+
+    void markAsRead(Long id, Long userId);
+
+    void deleteNotification(Long id, Long userId);
 }


### PR DESCRIPTION
 fix notification system and add dashboard endpoint

  - Remove noisy self-notifications on schedule create/update
  - Fix chat notifications: skip sender, remove duplicate OneSignal calls
  - Fix getAllNotifications to filter by current user (security fix)
  - Add ownership check to markAsRead and deleteNotification
  - Wrap all notification responses in ApiResponse for consistency
  - Remove POST /send endpoint (was notifying yourself)
  - Add markAsRead and deleteNotification endpoints
  - Wire reminder scheduler to save Notification rows to DB
  - Add dashboard endpoint with full UI data in single request
  - Add Swagger docs for dashboard endpoint